### PR TITLE
Allow lein executable configuration via env var

### DIFF
--- a/src/leiningen/modules.clj
+++ b/src/leiningen/modules.clj
@@ -148,7 +148,8 @@ the :checkouts option:
             (println "------------------------------------------------------------------------")
             (println " Building" (:name project) (:version project) (dump-profiles args))
             (println "------------------------------------------------------------------------")
-            (if-let [cmd (get-in project [:modules :subprocess] "lein")]
+            (if-let [cmd (get-in project [:modules :subprocess]
+                                 (or (System/getenv "LEIN_CMD") "lein"))]
               (binding [eval/*dir* (:root project)]
                 (let [exit-code (apply eval/sh (cons cmd args))]
                   (when (pos? exit-code)


### PR DESCRIPTION
Allows the specification of the leiningen executable path using the LEIN_CMD 
environment variable.

This allows configuration of the project in different environments (e.g.
travis, where the lein command is `lein2`).
