### PR TITLE
Preserve profile metadata

### DIFF
--- a/src/lein_modules/inheritance.clj
+++ b/src/lein_modules/inheritance.clj
@@ -10,7 +10,7 @@
   required for 2.3.4"
   [m]
   (if (:dependencies m)
-    (update-in m [:dependencies] normalizer)
+    (with-meta (update-in m [:dependencies] normalizer) (meta m))
     m))
 
 (defn filter-profiles


### PR DESCRIPTION
When inheriting profiles, ensure profile metadata is preserved.  This ensures
profiles with ^:repl or ^:sticky metadata behave correctly.