### PR TITLE
:sub-project arg for lein modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,14 @@ any of the following keys:
   directory. Regardless of this option, build order is always
   determined by module interdependence.
 
+* `:sub-module` - A string denoting which sub-project you wish to build
+  including all its dependencies in the project.  For instance if you 
+  have ten sub-modules and `lein modules` will build them all you can 
+  select one submodule and it will only run the task on that project
+  and any others it depends on.  This makesx it more efficent than 
+  `:dirs` as the build order and other sub-modules it relies on are 
+  discovered automatically.
+
 * `:parent` - A string denoting the relative path to the parent
   project's directory. If unset, the value of the `:relative-path` of
   Leiningen's `:parent` vector will be used, and if that's unset, the

--- a/src/leiningen/modules.clj
+++ b/src/leiningen/modules.clj
@@ -145,11 +145,10 @@
                           all-project-names (map id all-ordered-modules)        ; All the names to check against if we care about them.
                           to-build (loop [project-list [(id top-module)]   ; Get a list of all project names that need to be built.
                                           modules-to-build #{}]
-                                     (cond (empty? project-list) modules-to-build
-                                           :else
+                                     (if (empty? project-list) modules-to-build
                                            (let [sub-module-name (first project-list)
                                                  sub-module (first (filter #(= sub-module-name (id %)) all-ordered-modules))
-                                                 all-sub-module-deps (map #(first %) (:dependencies sub-module))
+                                                 all-sub-module-deps (map first (:dependencies sub-module))
                                                  sub-deps (filter (set all-sub-module-deps) all-project-names) ]
                                              (recur (distinct (concat (rest project-list) sub-deps )) (conj modules-to-build sub-module) ))))]
                       (apply -modules project (filter to-build all-ordered-modules) (drop 2 args)))

--- a/src/leiningen/modules.clj
+++ b/src/leiningen/modules.clj
@@ -3,6 +3,7 @@
             [leiningen.core.main :as main]
             [leiningen.core.eval :as eval]
             [leiningen.core.utils :as utils]
+            [clojure.string :as s]
             [clojure.java.io :as io])
   (:use [lein-modules.inheritance :only (inherit)]
         [lein-modules.common      :only (parent with-profiles read-project)]

--- a/src/leiningen/modules.clj
+++ b/src/leiningen/modules.clj
@@ -3,8 +3,8 @@
             [leiningen.core.main :as main]
             [leiningen.core.eval :as eval]
             [leiningen.core.utils :as utils]
-            [clojure.string :as s]
-            [clojure.java.io :as io])
+            [clojure.java.io :as io]
+            [clojure.string :as s])
   (:use [lein-modules.inheritance :only (inherit)]
         [lein-modules.common      :only (parent with-profiles read-project)]
         [lein-modules.compression :only (compressed-profiles)]))


### PR DESCRIPTION
HI Jim,
In our project we have approx 10 submodules which are interconnected in many ways.
lein modules always runs the selected task against all of them.  Whilst this is awesome, for a developer working in the middle of the stack to reduce feedback time from testing we have implemented :sub-module which builds the project they are working on and only the other modules which it depends on instead of the entire stack.

I can see other people finding this option very useful so we are contributing it back to you so others can gain this efficiency as well.

I've updated the README as well as documenting the modules method.

Please let me know if anything is amiss.

I've fully tested it on our stack, but unfortunately I do not have a automated test yet.

I hope this helps :D

P.S please get in touch for any questions either through here or by priv mail.  Many thanks