### PR TITLE
Quiet mode

### DIFF
--- a/src/leiningen/modules.clj
+++ b/src/leiningen/modules.clj
@@ -132,7 +132,10 @@
         (doseq [p modules]
           (if-not quiet?
             (println "  " (:name p))
-            (println (:name p)))))))
+            (println (:name p))))
+
+        ;; For the test suite, return all children.
+        (map id modules))))
 
 (defn modules
   "Run a task for all related projects in dependency order.

--- a/src/leiningen/modules.clj
+++ b/src/leiningen/modules.clj
@@ -163,6 +163,7 @@ will override the [:modules :dirs] config in project.clj
 Accepts '-q', '--quiet' and ':quiet' to suppress non-subprocess output."
   [project & args]
   (let [[quiet? args] ((juxt some remove) #{"-q" "--quiet" ":quiet"} args)
+        quiet? (or quiet? (-> project :modules :quiet))
         {:keys [quiet?] :as opts} {:quiet? (boolean quiet?)}]
     (condp = (first args)
     ":checkouts" (do
@@ -171,7 +172,8 @@ Accepts '-q', '--quiet' and ':quiet' to suppress non-subprocess output."
     ":dirs" (let [dirs (s/split (second args) #"[:,]")]
               (apply modules
                 (-> project
-                  (assoc-in [:modules :dirs] dirs)
+                    (assoc-in [:modules :dirs] dirs)
+                    (assoc-in [:modules :quiet] quiet?)
                   (vary-meta assoc-in [:without-profiles :modules :dirs] dirs))
                 (drop 2 args)))
     nil (print-modules opts (ordered-builds project))


### PR DESCRIPTION
Enable lein-modules to run quietly so that it composes with other stdout based tools.