### PR TITLE
Convert per-profile relative paths to source tree absolute paths

### DIFF
--- a/src/lein_modules/inheritance.clj
+++ b/src/lein_modules/inheritance.clj
@@ -17,16 +17,20 @@
 (defn normalize-paths
   "Converts any path lists in the profile to absolute paths."
   [m {:keys [root] :as project}]
-  (->> (for [k (keys m)
-             :when (.contains (name k) "-paths")]
-         [k (mapv (fn [p]
+  (as-> m %
+    (for [[k v] %
+          :when (.contains (name k) "-paths")]
+         [k (with-meta
+              (mapv (fn [p]
                     (if (and (string? p) (.startsWith p "//"))
                       (.getAbsolutePath
                        (io/file root (.replaceFirst p "//" "")))
                       p))
-                  (get m k))])
-       (into {})
-       (merge m)))
+                    v)
+              (meta v))])
+       (into {} %)
+       (merge m %)
+       (with-meta % (meta m))))
 
 (defn filter-profiles
   "We don't want to inherit the non-project-specific profiles or any

--- a/src/lein_modules/inheritance.clj
+++ b/src/lein_modules/inheritance.clj
@@ -20,11 +20,9 @@
   (->> (for [k (keys m)
              :when (.contains (name k) "-paths")]
          [k (mapv (fn [p]
-                    (if (string? p)
-                      (let [pf (io/file p)]
-                        (.getAbsolutePath
-                         (if-not (.isAbsolute pf)
-                           (io/file root p) pf)))
+                    (if (and (string? p) (.startsWith p "//"))
+                      (.getAbsolutePath
+                       (io/file root (.replaceFirst p "//" "")))
                       p))
                   (get m k))])
        (into {})


### PR DESCRIPTION
Upstreams FundingCircle/lein-modules#4

This fixes a "bug" (missing feature) in lein-modules where paths inherited from the parent project are interpreted to be relative to the inheriting child project, rather than being absolute with respect to the project from which they are inherited.

This behavior made it impossible to have for instance a shared `/dev` root source tree across all subproject in a repository as one could not pin the `/dev` path to the root of the repository.