### PR TITLE
Use relative paths for checkouts symlinks

### DIFF
--- a/src/leiningen/modules.clj
+++ b/src/leiningen/modules.clj
@@ -79,6 +79,13 @@
   "Sort a representation of interdependent projects topologically"
   (comp topological-sort interdependence progeny))
 
+(defn- relativize
+  "Returns the path to target relative to dir, as a String"
+  [dir target]
+  (-> (.relativize (.toPath dir) (.toPath target))
+    (.normalize)
+    str))
+
 (defn create-checkouts
   "Create checkout symlinks for interdependent projects"
   [projects]
@@ -90,8 +97,9 @@
         (println "Checkouts for" (:name project))
         (binding [eval/*dir* dir]
           (doseq [dep deps]
-            (eval/sh "rm" "-f" (:name dep))
-            (eval/sh "ln" "-sv" (:root dep) (:name dep))))))))
+            (let [target-name (relativize dir (io/file (:root dep)))]
+              (eval/sh "rm" "-f" (:name dep))
+              (eval/sh "ln" "-sv" target-name (:name dep)))))))))
 
 (def checkout-dependencies
   "Setup checkouts/ for a project and its interdependent children"


### PR DESCRIPTION
I run a lot of code in docker containers, in a VM on my laptop while using the
host machine for editing. Using relative paths for checkouts allows the
symlinks to remain valid when mounted into other filesystems.

I've assumed that modules must always be child directories of the parent
project, if that's not the case I also have a version of this that uses
relative paths when that's true and absolute paths otherwise.