### PR TITLE
Allow referring to current module version using _

### DIFF
--- a/src/lein_modules/versionization.clj
+++ b/src/lein_modules/versionization.clj
@@ -34,7 +34,7 @@
       opts)))
 
 (def project-versions (atom {}))
-(defn set-project-versions! [vs] (reset! project-versions vs))
+(defn set-project-versions! [vs] (swap! project-versions merge vs))
 
 (defn versionize
   "Substitute versions in dependency vectors with actual versions from

--- a/src/lein_modules/versionization.clj
+++ b/src/lein_modules/versionization.clj
@@ -33,12 +33,17 @@
         ver)
       opts)))
 
+(def project-versions (atom {}))
+(defn set-project-versions! [vs] (reset! project-versions vs))
+
 (defn versionize
   "Substitute versions in dependency vectors with actual versions from
   the :versions modules config"
   [project]
-  (let [vmap (merge (select-keys project [:version]) (versions project))
+  (let [vmap (merge (select-keys project [:version])
+                    @project-versions
+                    (versions project))
         f #(with-meta (for [d %] (expand-version d vmap)) (meta %))]
     (-> project
-      (update-in [:dependencies] f)
-      (update-in [:parent] expand-version vmap))))
+        (update-in [:dependencies] f)
+        (update-in [:parent] expand-version vmap))))


### PR DESCRIPTION
Sometimes in projects you want the internal dependencies of a module
to always refer to the current version of that module.  Having to edit
:versions in the parent every time a submodule version changes is a
solution, but one can forget to do so and also it's a bit against the
idea of self-discovery.  This little patch makes available the
versions of all modules to versionize, so that one can write

```clojure
["module-a" "_"]
```

as a dep in "module-b" to refer to the current version of "module-a"
in the project, without having to list "module-a" explictly in
:versions.

The patch is ugly in that it uses mutation to hook into `versionize`,
but modifying the actual versions maps in the project object in a way
that it's seen in substasks doesn't seem possible without touching the
project.clj.  Just a suggestion more than a fully fledged PR.