### PR TITLE
Removing CLASSPATH from the environment when launching lein

### DIFF
--- a/src/leiningen/modules.clj
+++ b/src/leiningen/modules.clj
@@ -191,7 +191,8 @@ Accepts '-q', '--quiet' and ':quiet' to suppress non-subprocess output."
           (println " Building" (:name project) (:version project) (dump-profiles args))
           (println "------------------------------------------------------------------------"))
         (if-let [cmd (get-in project [:modules :subprocess] subprocess)]
-          (binding [eval/*dir* (:root project)]
+          (binding [eval/*dir* (:root project)
+                    eval/*env* (with-meta (dissoc (into {} (System/getenv)) "CLASSPATH") {:replace true})]
             (let [exit-code (apply eval/sh (cons cmd args))]
               (when (pos? exit-code)
                 (throw (ex-info "Subprocess failed" {:exit-code exit-code})))))


### PR DESCRIPTION
Addresses #46 

This does not have tests associated with it, since it's a bit of a mess when running with leiningen 2.9.5.

I do have a simple module that no longer gives the CLASSPATH warning, and can work on automating the test if you want.