### PR TITLE
Partial fix for new Lein profile evaluation (Lein 2.9.3+)

### DIFF
--- a/src/leiningen/modules.clj
+++ b/src/leiningen/modules.clj
@@ -5,7 +5,8 @@
             [leiningen.core.utils :as utils]
             [clojure.java.io :as io]
             [clojure.string :as s])
-  (:use [lein-modules.inheritance :only (inherit)]
+  (:use
+        [lein-modules.plugin :only (middleware)]
         [lein-modules.common      :only (parent with-profiles read-project)]
         [lein-modules.compression :only (compressed-profiles)]))
 
@@ -185,7 +186,7 @@ Accepts '-q', '--quiet' and ':quiet' to suppress non-subprocess output."
                          (if (= :windows (utils/get-os)) "lein.bat" "lein")))]
       (when-not quiet?
         (print-modules opts modules))
-      (doseq [project modules]
+      (doseq [project  (map middleware modules)]
         (when-not quiet?
           (println "------------------------------------------------------------------------")
           (println " Building" (:name project) (:version project) (dump-profiles args))


### PR DESCRIPTION
This is working locally. It should address #45 partially.

The change is to apply the implicit middleware, which does the inheritance and version string substitution, in the `modules` plugin directly. When using the root lein process (`project.clj` has `:modules { :subprocess nil }`), this will ensure the `inherited` profile exists on the child modules. I haven not put much effort into making this work with `eval/sh` as I'm not sure how to properly apply  the middleware to external `project.clj`s.


TL;DR:
- set `:subprocess nil` and things work